### PR TITLE
add test with more complicated selector

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ipld/go-ipld-prime/schema"
-
-	dagpb "github.com/ipld/go-ipld-prime-proto"
-
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipld/go-ipld-prime"
+	dagpb "github.com/ipld/go-ipld-prime-proto"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
@@ -25,20 +23,19 @@ type FetcherConfig struct {
 
 type Fetcher interface {
 	// NodeMatching traverses a node graph starting with the provided node using the given selector and possibly crossing
-	// block boundaries. Each matched node is sent to the FetchResult channel.
-	// The results and error channels will be closed on query completion or error. The error channel is buffered,
-	// will emit at most one error and must be checked after processing the results.
-	NodeMatching(ctx context.Context, node ipld.Node, match selector.Selector) (<-chan FetchResult, <-chan error)
+	// block boundaries. Each matched node is sent to the FetchResult channel.  This method blocks until all results
+	// are read or an error occurs. The provided function will be called once for every result and possibly once with an
+	// error after which not be called.
+	NodeMatching(context.Context, ipld.Node, selector.Selector, FetchCallback)
 
 	// BlockOfType fetches a node graph of the provided type corresponding to single block by link.
-	BlockOfType(ctx context.Context, link ipld.Link, ptype ipld.NodePrototype) (ipld.Node, error)
+	BlockOfType(context.Context, ipld.Link, ipld.NodePrototype) (ipld.Node, error)
 
 	// BlockMatchingOfType traverses a node graph starting with the given link using the given selector and possibly
 	// crossing block boundaries. The nodes will be typed using the provided prototype. Each matched node is sent to
-	// the FetchResult channel.
-	// The results and error channels will be closed on query completion or error. The error channel is buffered,
-	// will emit at most one error and must be checked after processing the results.
-	BlockMatchingOfType(ctx context.Context, root ipld.Link, match selector.Selector, ptype ipld.NodePrototype) (<-chan FetchResult, <-chan error)
+	// the FetchResult channel. This method blocks until all results are read or an error occurs.
+	// The provided function will be called once for every result and possibly once with an error after which not be called.
+	BlockMatchingOfType(context.Context, ipld.Link, selector.Selector, ipld.NodePrototype, FetchCallback)
 }
 
 type fetcherSession struct {
@@ -51,6 +48,8 @@ type FetchResult struct {
 	LastBlockPath ipld.Path
 	LastBlockLink ipld.Link
 }
+
+type FetchCallback func(result FetchResult, err error)
 
 // NewFetcherConfig creates a FetchConfig from which session may be created and nodes retrieved.
 func NewFetcherConfig(blockService blockservice.BlockService) FetcherConfig {
@@ -77,47 +76,21 @@ func (f *fetcherSession) BlockOfType(ctx context.Context, link ipld.Link, ptype 
 	return nb.Build(), nil
 }
 
-func (f *fetcherSession) NodeMatching(ctx context.Context, node ipld.Node, match selector.Selector) (<-chan FetchResult, <-chan error) {
-	results := make(chan FetchResult)
-	errors := make(chan error, 1)
-
-	go func() {
-		defer close(results)
-		defer close(errors)
-
-		err := f.fetch(ctx, node, match, results)
-		if err != nil {
-			errors <- err
-			return
-		}
-	}()
-
-	return results, errors
+func (f *fetcherSession) NodeMatching(ctx context.Context, node ipld.Node, match selector.Selector, cb FetchCallback) {
+	f.fetch(ctx, node, match, cb)
 }
 
-func (f *fetcherSession) BlockMatchingOfType(ctx context.Context, root ipld.Link, match selector.Selector, ptype ipld.NodePrototype) (<-chan FetchResult, <-chan error) {
-	results := make(chan FetchResult)
-	errors := make(chan error, 1)
+func (f *fetcherSession) BlockMatchingOfType(ctx context.Context, root ipld.Link, match selector.Selector,
+	ptype ipld.NodePrototype, cb FetchCallback) {
 
-	go func() {
-		defer close(results)
-		defer close(errors)
+	// retrieve first node
+	node, err := f.BlockOfType(ctx, root, ptype)
+	if err != nil {
+		cb(FetchResult{}, err)
+		return
+	}
 
-		// retrieve first node
-		node, err := f.BlockOfType(ctx, root, ptype)
-		if err != nil {
-			errors <- err
-			return
-		}
-
-		err = f.fetch(ctx, node, match, results)
-		if err != nil {
-			errors <- err
-			return
-		}
-	}()
-
-	return results, errors
+	f.fetch(ctx, node, match, cb)
 }
 
 // Block fetches a schemaless node graph corresponding to single block by link.
@@ -131,46 +104,43 @@ func Block(ctx context.Context, f Fetcher, link ipld.Link) (ipld.Node, error) {
 
 // BlockMatching traverses a schemaless node graph starting with the given link using the given selector and possibly crossing
 // block boundaries. Each matched node is sent to the FetchResult channel.
-func BlockMatching(ctx context.Context, f Fetcher, root ipld.Link, match selector.Selector) (<-chan FetchResult, <-chan error) {
+func BlockMatching(ctx context.Context, f Fetcher, root ipld.Link, match selector.Selector, cb FetchCallback) {
 	prototype, err := prototypeFromLink(root)
 	if err != nil {
-		errors := make(chan error, 1)
-		errors <- err
-		return nil, errors
+		cb(FetchResult{}, err)
+		return
 	}
-	return f.BlockMatchingOfType(ctx, root, match, prototype)
+	f.BlockMatchingOfType(ctx, root, match, prototype, cb)
 }
 
 // BlockAll traverses all nodes in the graph linked by root. The nodes will be untyped and send over the results
 // channel.
-func BlockAll(ctx context.Context, f Fetcher, root ipld.Link) (<-chan FetchResult, <-chan error) {
+func BlockAll(ctx context.Context, f Fetcher, root ipld.Link, cb FetchCallback) {
 	prototype, err := prototypeFromLink(root)
 	if err != nil {
-		errors := make(chan error, 1)
-		errors <- err
-		return nil, errors
+		cb(FetchResult{}, err)
+		return
 	}
-	return BlockAllOfType(ctx, f, root, prototype)
+	BlockAllOfType(ctx, f, root, prototype, cb)
 }
 
 // BlockAllOfType traverses all nodes in the graph linked by root. The nodes will typed according to ptype
 // and send over the results channel.
-func BlockAllOfType(ctx context.Context, f Fetcher, root ipld.Link, ptype ipld.NodePrototype) (<-chan FetchResult, <-chan error) {
+func BlockAllOfType(ctx context.Context, f Fetcher, root ipld.Link, ptype ipld.NodePrototype, cb FetchCallback) {
 	ssb := builder.NewSelectorSpecBuilder(ptype)
 	allSelector, err := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreUnion(
 		ssb.Matcher(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
 	)).Selector()
 	if err != nil {
-		errors := make(chan error, 1)
-		errors <- err
-		return nil, errors
+		cb(FetchResult{}, err)
+		return
 	}
-	return f.BlockMatchingOfType(ctx, root, allSelector, ptype)
+	f.BlockMatchingOfType(ctx, root, allSelector, ptype, cb)
 }
 
-func (f *fetcherSession) fetch(ctx context.Context, node ipld.Node, match selector.Selector, results chan FetchResult) error {
-	return traversal.Progress{
+func (f *fetcherSession) fetch(ctx context.Context, node ipld.Node, match selector.Selector, cb FetchCallback) {
+	err := traversal.Progress{
 		Cfg: &traversal.Config{
 			LinkLoader: f.loader(ctx),
 			LinkTargetNodePrototypeChooser: dagpb.AddDagPBSupportToChooser(func(_ ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
@@ -181,14 +151,17 @@ func (f *fetcherSession) fetch(ctx context.Context, node ipld.Node, match select
 			}),
 		},
 	}.WalkMatching(node, match, func(prog traversal.Progress, n ipld.Node) error {
-		results <- FetchResult{
+		cb(FetchResult{
 			Node:          n,
 			Path:          prog.Path,
 			LastBlockPath: prog.LastBlock.Path,
 			LastBlockLink: prog.LastBlock.Link,
-		}
+		}, nil)
 		return nil
 	})
+	if err != nil {
+		cb(FetchResult{}, err)
+	}
 }
 
 func (f *fetcherSession) loader(ctx context.Context) ipld.Loader {

--- a/fetcher.go
+++ b/fetcher.go
@@ -23,18 +23,19 @@ type FetcherConfig struct {
 
 type Fetcher interface {
 	// NodeMatching traverses a node graph starting with the provided node using the given selector and possibly crossing
-	// block boundaries. Each matched node is sent to the FetchResult channel.  This method blocks until all results
-	// are read or an error occurs. The provided function will be called once for every result and possibly once with an
-	// error after which not be called.
+	// block boundaries. Each matched node is passed as FetchResult to the callback.
+	// The sequence of events is: NodeMatching begins, the callback is called zero or more times with a FetchResult, the
+	// callback is called zero or one time with an error, then NodeMatching returns.
 	NodeMatching(context.Context, ipld.Node, selector.Selector, FetchCallback)
 
 	// BlockOfType fetches a node graph of the provided type corresponding to single block by link.
 	BlockOfType(context.Context, ipld.Link, ipld.NodePrototype) (ipld.Node, error)
 
 	// BlockMatchingOfType traverses a node graph starting with the given link using the given selector and possibly
-	// crossing block boundaries. The nodes will be typed using the provided prototype. Each matched node is sent to
-	// the FetchResult channel. This method blocks until all results are read or an error occurs.
-	// The provided function will be called once for every result and possibly once with an error after which not be called.
+	// crossing block boundaries. The nodes will be typed using the provided prototype. Each matched node is passed as
+	// a FetchResult to the callback.
+	// The sequence of events is: BlockMatchingOfType begins, the callback is called zero or more times with a
+	// FetchResult, the callback is called zero or one time with an error, then BlockMatchingOfType returns.
 	BlockMatchingOfType(context.Context, ipld.Link, selector.Selector, ipld.NodePrototype, FetchCallback)
 }
 


### PR DESCRIPTION
closes #5

### Motivation

We've decided to go in a different direction with the go-fetcher interface. After some attempts to integrate go-fetcher with the rest of IPFS, we discovered that a callback interface will mesh a lot better with existing packages than channels we had been returning. This PR makes that change.

### What's in this PR

1. Introduce `FetchCallback` which is a function that takes a `FetchResult` or `error`.
2. Modify all fetcher methods that had returned channels to take and use a `FetchCallback` instead.
3. Modify tests to account for this change.
4. Add a test for path selection (this was actually a scratchpad for work done elsewhere, but it's good to exercise fetcher on more complicated IPLD queries).