### PR TITLE
Add a WithReifier method to allow easier derivation of non-unixfs pathing

### DIFF
--- a/impl/blockservice/fetcher.go
+++ b/impl/blockservice/fetcher.go
@@ -50,6 +50,16 @@ func (fc FetcherConfig) NewSession(ctx context.Context) fetcher.Fetcher {
 	return &fetcherSession{linkSystem: ls, protoChooser: protoChooser}
 }
 
+// WithReifier derives a different fetcher factory from the same source but
+// with a chosen NodeReifier for pathing semantics.
+func (fc FetcherConfig) WithReifier(nr ipld.NodeReifier) fetcher.Factory {
+	return FetcherConfig{
+		blockService:     fc.blockService,
+		NodeReifier:      nr,
+		PrototypeChooser: fc.PrototypeChooser,
+	}
+}
+
 // interface check
 var _ fetcher.Factory = FetcherConfig{}
 


### PR DESCRIPTION
dependency injection in IPFS means we can only get a single non-parameterized injection of a fetcher.Factory or Resolver.

We provide a method for downstream interface based derivation of what sort of reification semantics are desired.