### PR TITLE
add a fetcher constructor for the case where we already have a session

### DIFF
--- a/impl/blockservice/fetcher.go
+++ b/impl/blockservice/fetcher.go
@@ -39,11 +39,15 @@ func NewFetcherConfig(blockService blockservice.BlockService) FetcherConfig {
 // NewSession creates a session from which nodes may be retrieved.
 // The session ends when the provided context is canceled.
 func (fc FetcherConfig) NewSession(ctx context.Context) fetcher.Fetcher {
+	return fc.FetcherWithSession(ctx, blockservice.NewSession(ctx, fc.blockService))
+}
+
+func (fc FetcherConfig) FetcherWithSession(ctx context.Context, s *blockservice.Session) fetcher.Fetcher {
 	ls := cidlink.DefaultLinkSystem()
 	// while we may be loading blocks remotely, they are already hash verified by the time they load
 	// into ipld-prime
 	ls.TrustedStorage = true
-	ls.StorageReadOpener = blockOpener(ctx, blockservice.NewSession(ctx, fc.blockService))
+	ls.StorageReadOpener = blockOpener(ctx, s)
 	ls.NodeReifier = fc.NodeReifier
 
 	protoChooser := fc.PrototypeChooser


### PR DESCRIPTION
In a lot of cases we already have a bitswap session that we want to reuse, this makes that possible here